### PR TITLE
DEXI-792 Rest Resource List

### DIFF
--- a/src/form/field-handlers/EntityPicker.less
+++ b/src/form/field-handlers/EntityPicker.less
@@ -4,6 +4,7 @@
 .entity-picker {
     display: flex;
     flex-direction: row;
+    background-color: inherit;
 
     select {
         margin:5px;

--- a/src/form/field-handlers/EntityPicker.tsx
+++ b/src/form/field-handlers/EntityPicker.tsx
@@ -23,6 +23,8 @@ interface EntityPickerProps {
     allowObject?: boolean
     entities?: string[]
     onEntityCreated?: (entity: SchemaEntity) => void
+    label?: string
+    help?: string
 }
 
 interface ParsedValue {
@@ -175,7 +177,7 @@ export class EntityPicker extends React.Component<EntityPickerProps> {
         return (
             <>
                 <div className={"entity-picker"}>
-                    <DropdownInput value={parsedValue.type} validation={["required"]} label="" name="" 
+                    <DropdownInput value={parsedValue.type} validation={["required"]} label={this.props.label ? this.props.label : ""} name={""} help={this.props.help ? this.props.help : ""}
                         onChange={(_,value)=>{
                             
                             this.onSelectHandler(value)


### PR DESCRIPTION
The entity picker uses the Dropdown component. Initially it was impossible to provide a label or a help message to the dropdown through the Entity Picker. I have added the functionality of passing the dropdown label and message as props to the Entity Picker. 
This was needed for the Create Method Form inside the RESTEditorCompoment ( provider-resource-internal-rest )