### PR TITLE
fix: Avoid state changes when there are none

### DIFF
--- a/src/form/FormContainer.tsx
+++ b/src/form/FormContainer.tsx
@@ -93,6 +93,10 @@ export class FormContainer extends React.Component<Props, State> {
     }
 
     private onReadyStateChanged(fieldName: string, ready: boolean) {
+        if (this.state.readyStates[fieldName] === ready) {
+            //If state didnt change - do nothing
+            return;
+        }
         this.setState((state: State) => {
             state.readyStates[fieldName] = ready;
             state.valid = this.isValid(state.readyStates);

--- a/stories/forms.stories.tsx
+++ b/stories/forms.stories.tsx
@@ -9,6 +9,7 @@ import {
     FormContainer,
 } from '../src';
 import { FormField, FormFieldType } from '../src/form/inputs/FormField';
+import {useFormContextField} from "../src/form/FormContext";
 
 function minMaxAgeCheck(name: string, value: number) {
     if (value < 1) {
@@ -225,8 +226,26 @@ export const FormWithConditionals = () => {
     );
 };
 
+function failValidation(name, value) {
+    if (value === 'fail')
+        throw new Error('Cannot be "fail"')
+}
+
+const CustomFormComponent = () => {
+    const simpleHook = useFormContextField('simplehook');
+
+    return (
+        <FormField
+            name={'simple'}
+            label={'Simple'}
+            validation={['required', failValidation]}
+        />
+    );
+}
+
 export const FormWithValidation = () => {
     const [formData, setFormData] = useState({});
+
 
     return (
         <div style={{ width: '550px' }}>
@@ -236,9 +255,10 @@ export const FormWithValidation = () => {
                     setFormData(data);
                 }}
             >
-                <FormField name={'name'} label={'Name'} validation={['required']} />
+                <FormField name={'name'} label={'Name'} validation={['required', failValidation]} />
                 <FormField name={'email'} label={'E-mail'} validation={['required', 'email']} />
                 <FormField name={'enabled'} label={'Enable?'} type={FormFieldType.CHECKBOX} />
+                <CustomFormComponent />
 
                 <FormField
                     name={'age'}


### PR DESCRIPTION
We're setting readystate more often now but to the same value which causes infinite rerendering of the entire form

This ensures that we only react to actual changes