### PR TITLE
fix: Don't add maxWidth to base el

### DIFF
--- a/src/tooltip/Tooltip.tsx
+++ b/src/tooltip/Tooltip.tsx
@@ -5,7 +5,7 @@ export type TooltipProps = MuiTooltipProps & {
     maxWidth?: number;
 };
 
-export const Tooltip = styled(({ className, ...props }: TooltipProps) => (
+export const Tooltip = styled(({ className, maxWidth, ...props }: TooltipProps) => (
     <MuiTooltip {...props} classes={{ popper: className }} />
 ))(({ theme, maxWidth }) => ({
     [`& .${tooltipClasses.arrow}::before`]: {


### PR DESCRIPTION
`maxWidth` was by mistake added to the root element and React complained about that. 