### PR TITLE
Change default elevation of confirm dialog

### DIFF
--- a/src/confirm/ConfirmationDialog.tsx
+++ b/src/confirm/ConfirmationDialog.tsx
@@ -82,7 +82,16 @@ export const ConfirmationDialog = ({ open, options, onCancel, onConfirm, onClose
     });
 
     return (
-        <Dialog fullWidth maxWidth="xs" {...dialogProps} open={open} onClose={allowClose ? onClose : null}>
+        <Dialog
+            fullWidth
+            maxWidth="xs"
+            {...dialogProps}
+            open={open}
+            onClose={allowClose ? onClose : null}
+            PaperProps={{
+                elevation: 23,
+            }}
+        >
             {title && <DialogTitle {...titleProps}>{title}</DialogTitle>}
             {content ? (
                 <DialogContent {...contentProps}>


### PR DESCRIPTION
Design token for 24 (the default elevation) is missing, so I am changing it to 23 for now.