### PR TITLE
Revert to hardcoded margin on inputs & Add DefaultFormLayout component

### DIFF
--- a/src/form/DefaultFormLayout.tsx
+++ b/src/form/DefaultFormLayout.tsx
@@ -1,0 +1,23 @@
+import { Box } from '@mui/material';
+import React, { PropsWithChildren } from 'react';
+
+type DefaultFormLayoutProps = PropsWithChildren<{
+    gap?: number;
+}>;
+
+export default function DefaultFormLayout({ children, gap = 3 }: DefaultFormLayoutProps) {
+    return (
+        <Box
+            display="flex"
+            flexDirection="column"
+            gap={gap}
+            sx={{
+                '.MuiFormControl-root': {
+                    my: 0,
+                },
+            }}
+        >
+            {children}
+        </Box>
+    );
+}

--- a/src/form/inputs/FormCheckbox.tsx
+++ b/src/form/inputs/FormCheckbox.tsx
@@ -30,6 +30,7 @@ export const FormCheckbox = withFormFieldController((props: Props, controller) =
             error={controller.showError}
             sx={{
                 display: 'block',
+                my: 1,
                 '.MuiFormHelperText-root': {
                     ml: 0,
                 },

--- a/src/form/inputs/FormField.tsx
+++ b/src/form/inputs/FormField.tsx
@@ -39,7 +39,11 @@ interface InnerElementProps extends SharedFormFieldProps, FieldProps {
     type?: FormFieldType;
 }
 
-const InnerElement = ({ type: formFieldType = FormFieldType.STRING, ...props }: InnerElementProps) => {
+const InnerElement = ({
+    type: formFieldType = FormFieldType.STRING,
+    variant = 'standard',
+    ...props
+}: InnerElementProps) => {
     switch (formFieldType) {
         case FormFieldType.ENUM:
         case FormFieldType.ENUM_MULTI:
@@ -51,22 +55,22 @@ const InnerElement = ({ type: formFieldType = FormFieldType.STRING, ...props }: 
                     multi={formFieldType === FormFieldType.ENUM_MULTI}
                     options={props.options}
                     {...props}
-                    variant={props.variant}
+                    variant={variant}
                 />
             );
 
         case FormFieldType.STRING:
-            return <FormInput type={Type.TEXT} {...props} variant={props.variant} />;
+            return <FormInput type={Type.TEXT} {...props} variant={variant} />;
         case FormFieldType.TEXT:
-            return <FormTextarea {...props} variant={props.variant} />;
+            return <FormTextarea {...props} variant={variant} />;
         case FormFieldType.DATE:
-            return <FormInput type={Type.DATE} {...props} variant={props.variant} />;
+            return <FormInput type={Type.DATE} {...props} variant={variant} />;
         case FormFieldType.NUMBER:
-            return <FormInput type={Type.NUMBER} {...props} variant={props.variant} />;
+            return <FormInput type={Type.NUMBER} {...props} variant={variant} />;
         case FormFieldType.EMAIL:
-            return <FormInput type={Type.EMAIL} {...props} variant={props.variant} />;
+            return <FormInput type={Type.EMAIL} {...props} variant={variant} />;
         case FormFieldType.PASSWORD:
-            return <FormInput type={Type.PASSWORD} {...props} variant={props.variant} />;
+            return <FormInput type={Type.PASSWORD} {...props} variant={variant} />;
         case FormFieldType.CHECKBOX:
             return <FormCheckbox {...props} />;
         case FormFieldType.RADIO: {

--- a/src/form/inputs/FormInput.tsx
+++ b/src/form/inputs/FormInput.tsx
@@ -60,13 +60,14 @@ export const FormInput = withFormFieldController<string | number | boolean>((pro
             <TextField
                 sx={{
                     display: 'block',
+                    my: 1,
                     '.MuiInputBase-root': {
                         width: '100%',
                     },
                 }}
                 autoFocus={controller.autoFocus}
                 onChange={onChange}
-                variant={controller.variant}
+                variant={controller.variant || 'standard'}
                 label={controller.label}
                 helperText={controller.help}
                 disabled={controller.disabled}

--- a/src/form/inputs/FormRadioGroup.tsx
+++ b/src/form/inputs/FormRadioGroup.tsx
@@ -66,6 +66,7 @@ export const FormRadioGroup = withFormFieldController((props: Props, controller)
             variant={controller.variant}
             sx={{
                 display: 'block',
+                my: 1,
                 '.MuiFormHelperText-root': {
                     ml: 0,
                 },

--- a/src/form/inputs/FormSelect.tsx
+++ b/src/form/inputs/FormSelect.tsx
@@ -36,6 +36,7 @@ export const FormSelect = withFormFieldController<string | string[]>((props: For
         <TextField
             sx={{
                 display: 'block',
+                my: 1,
                 '.MuiInputBase-root': {
                     minWidth: '100%',
                 },

--- a/src/form/inputs/FormTextarea.tsx
+++ b/src/form/inputs/FormTextarea.tsx
@@ -20,6 +20,7 @@ export const FormTextarea = withFormFieldController((props: Props, controller) =
             <TextField
                 sx={{
                     display: 'block',
+                    my: 1,
                     '.MuiInputBase-root': {
                         width: '100%',
                     },

--- a/src/special/oauth/AuthScopesField.tsx
+++ b/src/special/oauth/AuthScopesField.tsx
@@ -75,6 +75,7 @@ export const AuthScopesField = (props: AuthScopesFieldProps) => {
                         borderRadius: '100%',
                         border: '2px solid',
                         borderColor: 'primary.main',
+                        my: 1,
                     }}
                 >
                     <BadgeOutlinedIcon fontSize="large" />

--- a/stories/form-elements.stories.tsx
+++ b/stories/form-elements.stories.tsx
@@ -6,7 +6,7 @@ import { Checkbox } from '../src/form/Checkbox';
 import { FormAutocomplete } from '../src/form/inputs/FormAutocomplete';
 import Chip from '@mui/material/Chip';
 import Avatar from '@mui/material/Avatar';
-import { Box, Button, Modal } from '@mui/material';
+import { Button } from '@mui/material';
 
 let dropdownState = new Store({
     test1: [],
@@ -37,13 +37,11 @@ export const FormInputs = () => {
     return (
         <div style={{ padding: '15px' }}>
             <FormContainer>
-                <Box display="flex" flexDirection="column" gap={2}>
-                    <FormInput help={helpText} name={'text'} label={'Text Value'} type={Type.TEXT} />
-                    <FormInput help={helpText} name={'email'} label={'Email Value'} type={Type.EMAIL} />
-                    <FormInput help={helpText} name={'num'} label={'Number Value'} type={Type.NUMBER} />
-                    <FormInput help={helpText} name={'pw'} label={'Password Value'} type={Type.PASSWORD} />
-                    <FormInput help={helpText} name={'date'} label={'Date Value'} type={Type.DATE} />
-                </Box>
+                <FormInput help={helpText} name={'text'} label={'Text Value'} type={Type.TEXT} />
+                <FormInput help={helpText} name={'email'} label={'Email Value'} type={Type.EMAIL} />
+                <FormInput help={helpText} name={'num'} label={'Number Value'} type={Type.NUMBER} />
+                <FormInput help={helpText} name={'pw'} label={'Password Value'} type={Type.PASSWORD} />
+                <FormInput help={helpText} name={'date'} label={'Date Value'} type={Type.DATE} />
             </FormContainer>
         </div>
     );
@@ -55,11 +53,9 @@ export const FormTextareas = () => {
     return (
         <div style={{ padding: '15px' }}>
             <FormContainer>
-                <Box display="flex" flexDirection="column" gap={2}>
-                    <FormInput help={helpText} name={'text'} label={'Text Value'} type={Type.TEXT} />
-                    <FormTextarea help={helpText} name={'multi'} label={'Multi line'} validation={['required']} />
-                    <FormInput help={helpText} name={'text'} label={'Text Value'} type={Type.TEXT} />
-                </Box>
+                <FormInput help={helpText} name={'text'} label={'Text Value'} type={Type.TEXT} />
+                <FormTextarea help={helpText} name={'multi'} label={'Multi line'} validation={['required']} />
+                <FormInput help={helpText} name={'text'} label={'Text Value'} type={Type.TEXT} />
             </FormContainer>
         </div>
     );
@@ -77,11 +73,9 @@ export const FormSelects = () => {
     return (
         <div style={{ padding: '15px' }}>
             <FormContainer>
-                <Box display="flex" flexDirection="column" gap={2}>
-                    <FormInput help={helpText} name={'text'} label={'Text Value'} type={Type.TEXT} />
-                    <FormSelect help={helpText} name={'multi'} label={'Multi line'} options={options} />
-                    <FormInput help={helpText} name={'text'} label={'Text Value'} type={Type.TEXT} />
-                </Box>
+                <FormInput help={helpText} name={'text'} label={'Text Value'} type={Type.TEXT} />
+                <FormSelect help={helpText} name={'multi'} label={'Multi line'} options={options} />
+                <FormInput help={helpText} name={'text'} label={'Text Value'} type={Type.TEXT} />
             </FormContainer>
         </div>
     );
@@ -100,54 +94,52 @@ export const MixedInputs = () => {
             }}
         >
             <form onSubmit={handleSubmit}>
-                <Box display="flex" flexDirection="column" gap={2}>
-                    <FormInput
-                        name={'SingleInput1'}
-                        value={'Test value'}
-                        label={'Single line input'}
-                        validation={['required']}
-                        help={'Specify the name of your block.'}
-                        onChange={inputReturnCallback}
-                    />
+                <FormInput
+                    name={'SingleInput1'}
+                    value={'Test value'}
+                    label={'Single line input'}
+                    validation={['required']}
+                    help={'Specify the name of your block.'}
+                    onChange={inputReturnCallback}
+                />
 
-                    <FormInput
-                        name={'SingleInput2'}
-                        value={''}
-                        label={'Single line input'}
-                        validation={['required']}
-                        help={'Specify the name of your block.'}
-                        onChange={inputReturnCallback}
-                    />
+                <FormInput
+                    name={'SingleInput2'}
+                    value={''}
+                    label={'Single line input'}
+                    validation={['required']}
+                    help={'Specify the name of your block.'}
+                    onChange={inputReturnCallback}
+                />
 
-                    <FormInput
-                        name={'SingleInput3'}
-                        value={''}
-                        label={'Single line input type number'}
-                        validation={['required']}
-                        help={'Specify the ID of your block.'}
-                        type={Type.NUMBER}
-                        onChange={inputReturnCallback}
-                    />
+                <FormInput
+                    name={'SingleInput3'}
+                    value={''}
+                    label={'Single line input type number'}
+                    validation={['required']}
+                    help={'Specify the ID of your block.'}
+                    type={Type.NUMBER}
+                    onChange={inputReturnCallback}
+                />
 
-                    <FormTextarea
-                        name={'MultiLineInput1'}
-                        value={''}
-                        label={'Multiline line input disabled'}
-                        validation={['required']}
-                        help={'Specify the description of your block.'}
-                        onChange={inputReturnCallback}
-                        disabled={true}
-                    />
-                    <FormTextarea
-                        name={'MultiLineInput2'}
-                        value={''}
-                        label={'Multiline line input'}
-                        validation={['required']}
-                        help={'Specify the description of your block.'}
-                        onChange={inputReturnCallback}
-                    />
-                    <input type="submit" value="Submit" />
-                </Box>
+                <FormTextarea
+                    name={'MultiLineInput1'}
+                    value={''}
+                    label={'Multiline line input disabled'}
+                    validation={['required']}
+                    help={'Specify the description of your block.'}
+                    onChange={inputReturnCallback}
+                    disabled={true}
+                />
+                <FormTextarea
+                    name={'MultiLineInput2'}
+                    value={''}
+                    label={'Multiline line input'}
+                    validation={['required']}
+                    help={'Specify the description of your block.'}
+                    onChange={inputReturnCallback}
+                />
+                <input type="submit" value="Submit" />
             </form>
         </div>
     );
@@ -322,111 +314,109 @@ export const FormAutocompletes = () => {
                     setFormData(data);
                 }}
             >
-                <Box display="flex" flexDirection="column" gap={2}>
-                    <FormAutocomplete
-                        name="best_movie_of_all_time"
-                        label="Best movie of all time"
-                        onChange={(name, value) => {
-                            console.log(name, value);
-                        }}
-                        options={top100Movies}
-                        getOptionLabel={(option) => {
-                            const isMovieOption = typeof option === 'object' && 'name' in option;
-                            return isMovieOption ? option.name : option;
-                        }}
-                        isOptionEqualToValue={(option, value) => value?.name === option.name}
-                        autoHighlight // Highlight first match in the listbox
-                        autoFocus
-                    />
+                <FormAutocomplete
+                    name="best_movie_of_all_time"
+                    label="Best movie of all time"
+                    onChange={(name, value) => {
+                        console.log(name, value);
+                    }}
+                    options={top100Movies}
+                    getOptionLabel={(option) => {
+                        const isMovieOption = typeof option === 'object' && 'name' in option;
+                        return isMovieOption ? option.name : option;
+                    }}
+                    isOptionEqualToValue={(option, value) => value?.name === option.name}
+                    autoHighlight // Highlight first match in the listbox
+                    autoFocus
+                />
 
-                    <FormAutocomplete
-                        name="top_3_movies"
-                        label="Top 3 movies"
-                        onChange={(name, value) => {
-                            console.log(name, value);
-                        }}
-                        options={top100Movies}
-                        getOptionLabel={(option) => {
+                <FormAutocomplete
+                    name="top_3_movies"
+                    label="Top 3 movies"
+                    onChange={(name, value) => {
+                        console.log(name, value);
+                    }}
+                    options={top100Movies}
+                    getOptionLabel={(option) => {
+                        const isMovieOption = typeof option === 'object' && 'name' in option;
+                        return isMovieOption ? option.name : option;
+                    }}
+                    isOptionEqualToValue={(option, value) => value?.name === option.name}
+                    hidePopupIndicator
+                    multiple
+                    limitTags={3} // Max tags to show when multiple
+                    filterSelectedOptions // Hide selected options
+                    autoHighlight // Highlight first match
+                    freeSolo // Allow free text
+                    // Example of how to render the options
+                    renderOption={(props, option, state) => {
+                        return (
+                            <li {...props}>
+                                <span>
+                                    <strong>{option.name}</strong> ({option.year})
+                                </span>
+                            </li>
+                        );
+                    }}
+                    // Example of how to render tags
+                    renderTags={(value, getTagProps, ownerState) => {
+                        return value.map((option, index) => {
                             const isMovieOption = typeof option === 'object' && 'name' in option;
-                            return isMovieOption ? option.name : option;
-                        }}
-                        isOptionEqualToValue={(option, value) => value?.name === option.name}
-                        hidePopupIndicator
-                        multiple
-                        limitTags={3} // Max tags to show when multiple
-                        filterSelectedOptions // Hide selected options
-                        autoHighlight // Highlight first match
-                        freeSolo // Allow free text
-                        // Example of how to render the options
-                        renderOption={(props, option, state) => {
                             return (
-                                <li {...props}>
-                                    <span>
-                                        <strong>{option.name}</strong> ({option.year})
-                                    </span>
-                                </li>
+                                <Chip
+                                    avatar={
+                                        <Avatar>
+                                            {isMovieOption ? option.name.charAt(0) : (option as string).charAt(0)}
+                                        </Avatar>
+                                    }
+                                    label={isMovieOption ? option.name : option}
+                                    {...getTagProps({ index })}
+                                    style={{ marginRight: 5 }}
+                                    variant="outlined"
+                                    color="primary"
+                                />
                             );
-                        }}
-                        // Example of how to render tags
-                        renderTags={(value, getTagProps, ownerState) => {
-                            return value.map((option, index) => {
-                                const isMovieOption = typeof option === 'object' && 'name' in option;
-                                return (
-                                    <Chip
-                                        avatar={
-                                            <Avatar>
-                                                {isMovieOption ? option.name.charAt(0) : (option as string).charAt(0)}
-                                            </Avatar>
-                                        }
-                                        label={isMovieOption ? option.name : option}
-                                        {...getTagProps({ index })}
-                                        style={{ marginRight: 5 }}
-                                        variant="outlined"
-                                        color="primary"
-                                    />
-                                );
-                            });
-                        }}
-                    />
+                        });
+                    }}
+                />
 
-                    <FormAutocomplete
-                        name="search_for_a_movie"
-                        label="Search for a movie (API)"
-                        onChange={(name, value) => {
-                            console.log('onChange', { name, value });
-                        }}
-                        onInputChange={async (event, value, reason) => {
-                            console.log('onInputChange', { event, value, reason });
+                <FormAutocomplete
+                    name="search_for_a_movie"
+                    label="Search for a movie (API)"
+                    onChange={(name, value) => {
+                        console.log('onChange', { name, value });
+                    }}
+                    onInputChange={async (event, value, reason) => {
+                        console.log('onInputChange', { event, value, reason });
 
-                            // Simulate API call
-                            setIsLoadingMovies(true);
-                            await new Promise((resolve) => setTimeout(resolve, 500));
-                            const filteredMovies =
-                                value === ''
-                                    ? []
-                                    : top100Movies.filter((movie) =>
-                                          movie.name.toLowerCase().includes(value.toLowerCase())
-                                      );
-                            setApiMovies(filteredMovies);
-                            setIsLoadingMovies(false);
-                        }}
-                        loading={isLoadingMovies}
-                        options={apiMovies}
-                        getOptionLabel={(option) => {
-                            const isMovieOption = typeof option === 'object' && 'name' in option;
-                            return isMovieOption ? option.name : option;
-                        }}
-                        isOptionEqualToValue={(option, value) => value?.name === option.name}
-                        autoHighlight // Highlight first match
-                        freeSolo // Allow free text
-                    />
+                        // Simulate API call
+                        setIsLoadingMovies(true);
+                        await new Promise((resolve) => setTimeout(resolve, 500));
+                        const filteredMovies =
+                            value === ''
+                                ? []
+                                : top100Movies.filter((movie) =>
+                                      movie.name.toLowerCase().includes(value.toLowerCase())
+                                  );
+                        setApiMovies(filteredMovies);
+                        setIsLoadingMovies(false);
+                    }}
+                    loading={isLoadingMovies}
+                    options={apiMovies}
+                    getOptionLabel={(option) => {
+                        const isMovieOption = typeof option === 'object' && 'name' in option;
+                        return isMovieOption ? option.name : option;
+                    }}
+                    isOptionEqualToValue={(option, value) => value?.name === option.name}
+                    autoHighlight // Highlight first match
+                    freeSolo // Allow free text
+                />
 
-                    <FormButtons>
-                        <Button type={'submit'} color="primary" variant="contained">
-                            Save
-                        </Button>
-                    </FormButtons>
-                </Box>
+                <FormButtons>
+                    <Button type={'submit'} color="primary" variant="contained">
+                        Save
+                    </Button>
+                </FormButtons>
             </FormContainer>
 
             <b>Submitted data</b>

--- a/stories/forms.stories.tsx
+++ b/stories/forms.stories.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from 'react';
 import { AsyncValidatorFunction, debouncedValidator, FormButtons, FormContainer } from '../src';
 import { FormField, FormFieldType } from '../src/form/inputs/FormField';
 import { useFormContextField } from '../src/form/FormContext';
-import { Box, Button } from '@mui/material';
+import { Button } from '@mui/material';
 
 function minMaxAgeCheck(name: string, value: number) {
     if (value < 1) {
@@ -45,63 +45,61 @@ export const SimpleForm = () => {
                     setFormData(data);
                 }}
             >
-                <Box display="flex" flexDirection="column" gap={2}>
-                    <FormField name={'name'} label={'Name'} />
-                    <FormField name={'age'} label={'Age'} type={FormFieldType.NUMBER} />
-                    <FormField
-                        name={'enabled'}
-                        label={'Enable?'}
-                        type={FormFieldType.CHECKBOX}
-                        help={'Should this be enabled?'}
-                    />
+                <FormField name={'name'} label={'Name'} />
+                <FormField name={'age'} label={'Age'} type={FormFieldType.NUMBER} />
+                <FormField
+                    name={'enabled'}
+                    label={'Enable?'}
+                    type={FormFieldType.CHECKBOX}
+                    help={'Should this be enabled?'}
+                />
 
-                    <FormField
-                        name={'radios'}
-                        label={'Radios'}
-                        type={FormFieldType.RADIO}
-                        help={'Pick one of these'}
-                        options={{ one: 'One', two: 'Two', three: 'Three' }}
-                    />
+                <FormField
+                    name={'radios'}
+                    label={'Radios'}
+                    type={FormFieldType.RADIO}
+                    help={'Pick one of these'}
+                    options={{ one: 'One', two: 'Two', three: 'Three' }}
+                />
 
-                    <FormField
-                        name={'select_multi'}
-                        label={'Select Multi'}
-                        type={FormFieldType.ENUM_MULTI}
-                        help={'You can choose multiple'}
-                        options={{ one: 'One', two: 'Two', three: 'Three' }}
-                    />
+                <FormField
+                    name={'select_multi'}
+                    label={'Select Multi'}
+                    type={FormFieldType.ENUM_MULTI}
+                    help={'You can choose multiple'}
+                    options={{ one: 'One', two: 'Two', three: 'Three' }}
+                />
 
-                    <FormField
-                        name={'select_one'}
-                        label={'Select One'}
-                        type={FormFieldType.ENUM}
-                        help={'Just one please'}
-                        options={{ one: 'One', two: 'Two', three: 'Three' }}
-                    />
+                <FormField
+                    name={'select_one'}
+                    label={'Select One'}
+                    type={FormFieldType.ENUM}
+                    help={'Just one please'}
+                    options={{ one: 'One', two: 'Two', three: 'Three' }}
+                />
 
-                    <FormField
-                        name={'select_empty'}
-                        label={'Select Empty'}
-                        type={FormFieldType.ENUM}
-                        help={'Just one please'}
-                        options={{ one: 'One', two: 'Two', three: 'Three' }}
-                    />
+                <FormField
+                    name={'select_empty'}
+                    label={'Select Empty'}
+                    type={FormFieldType.ENUM}
+                    help={'Just one please'}
+                    options={{ one: 'One', two: 'Two', three: 'Three' }}
+                />
 
-                    <FormButtons>
-                        <Button variant={'contained'} onClick={() => setInitialValue(AltFormValue)}>
-                            Load Alt
-                        </Button>
-                        <Button variant={'contained'} onClick={() => setInitialValue(InitialFormValue)}>
-                            Load Normal
-                        </Button>
-                        <Button variant={'contained'} type={'reset'} color={'error'}>
-                            Reset
-                        </Button>
-                        <Button variant={'contained'} type={'submit'} color={'primary'}>
-                            Save
-                        </Button>
-                    </FormButtons>
-                </Box>
+                <FormButtons>
+                    <Button variant={'contained'} onClick={() => setInitialValue(AltFormValue)}>
+                        Load Alt
+                    </Button>
+                    <Button variant={'contained'} onClick={() => setInitialValue(InitialFormValue)}>
+                        Load Normal
+                    </Button>
+                    <Button variant={'contained'} type={'reset'} color={'error'}>
+                        Reset
+                    </Button>
+                    <Button variant={'contained'} type={'submit'} color={'primary'}>
+                        Save
+                    </Button>
+                </FormButtons>
             </FormContainer>
             <b>Submitted data</b>
             <pre>{JSON.stringify(formData, null, 2)}</pre>
@@ -121,49 +119,47 @@ export const NestedDataForm = () => {
                     setFormData(data);
                 }}
             >
-                <Box display="flex" flexDirection="column" gap={2}>
-                    <FormField name={'author.name'} label={'Name'} />
-                    <FormField name={'author.age'} label={'Age'} type={FormFieldType.NUMBER} />
-                    <FormField
-                        name={'enabled'}
-                        label={'Enable?'}
-                        type={FormFieldType.CHECKBOX}
-                        help={'Should this be enabled?'}
-                    />
+                <FormField name={'author.name'} label={'Name'} />
+                <FormField name={'author.age'} label={'Age'} type={FormFieldType.NUMBER} />
+                <FormField
+                    name={'enabled'}
+                    label={'Enable?'}
+                    type={FormFieldType.CHECKBOX}
+                    help={'Should this be enabled?'}
+                />
 
-                    <FormField
-                        name={'radios'}
-                        label={'Radios'}
-                        type={FormFieldType.RADIO}
-                        help={'Pick one of these'}
-                        options={{ one: 'One', two: 'Two', three: 'Three' }}
-                    />
+                <FormField
+                    name={'radios'}
+                    label={'Radios'}
+                    type={FormFieldType.RADIO}
+                    help={'Pick one of these'}
+                    options={{ one: 'One', two: 'Two', three: 'Three' }}
+                />
 
-                    <FormField
-                        name={'options.select_multi'}
-                        label={'Select Multi'}
-                        type={FormFieldType.ENUM_MULTI}
-                        help={'You can choose multiple'}
-                        options={{ one: 'One', two: 'Two', three: 'Three' }}
-                    />
+                <FormField
+                    name={'options.select_multi'}
+                    label={'Select Multi'}
+                    type={FormFieldType.ENUM_MULTI}
+                    help={'You can choose multiple'}
+                    options={{ one: 'One', two: 'Two', three: 'Three' }}
+                />
 
-                    <FormField
-                        name={'options.select_one'}
-                        label={'Select One'}
-                        type={FormFieldType.ENUM}
-                        help={'Just one please'}
-                        options={{ one: 'One', two: 'Two', three: 'Three' }}
-                    />
+                <FormField
+                    name={'options.select_one'}
+                    label={'Select One'}
+                    type={FormFieldType.ENUM}
+                    help={'Just one please'}
+                    options={{ one: 'One', two: 'Two', three: 'Three' }}
+                />
 
-                    <FormButtons>
-                        <Button variant={'contained'} color={'error'}>
-                            Reset
-                        </Button>
-                        <Button variant={'contained'} type={'submit'} color={'primary'}>
-                            Save
-                        </Button>
-                    </FormButtons>
-                </Box>
+                <FormButtons>
+                    <Button variant={'contained'} color={'error'}>
+                        Reset
+                    </Button>
+                    <Button variant={'contained'} type={'submit'} color={'primary'}>
+                        Save
+                    </Button>
+                </FormButtons>
             </FormContainer>
             <b>Submitted data</b>
             <pre>{JSON.stringify(formData, null, 2)}</pre>
@@ -185,53 +181,51 @@ export const FormWithConditionals = () => {
                     setFormData(data);
                 }}
             >
-                <Box display="flex" flexDirection="column" gap={2}>
-                    <FormField name={'name'} label={'Name'} />
-                    <FormField name={'age'} label={'Age'} type={FormFieldType.NUMBER} />
-                    <FormField
-                        name={'enabled'}
-                        label={'Enable?'}
-                        type={FormFieldType.CHECKBOX}
-                        help={'Should this be enabled?'}
-                    />
+                <FormField name={'name'} label={'Name'} />
+                <FormField name={'age'} label={'Age'} type={FormFieldType.NUMBER} />
+                <FormField
+                    name={'enabled'}
+                    label={'Enable?'}
+                    type={FormFieldType.CHECKBOX}
+                    help={'Should this be enabled?'}
+                />
 
-                    {formData.enabled && (
-                        <div>
-                            <FormField
-                                name={'radios'}
-                                label={'Radios'}
-                                type={FormFieldType.RADIO}
-                                help={'Pick one of these'}
-                                options={{ one: 'One', two: 'Two', three: 'Three' }}
-                            />
+                {formData.enabled && (
+                    <div>
+                        <FormField
+                            name={'radios'}
+                            label={'Radios'}
+                            type={FormFieldType.RADIO}
+                            help={'Pick one of these'}
+                            options={{ one: 'One', two: 'Two', three: 'Three' }}
+                        />
 
-                            <FormField
-                                name={'select_multi'}
-                                label={'Select Multi'}
-                                type={FormFieldType.ENUM_MULTI}
-                                help={'You can choose multiple'}
-                                options={{ one: 'One', two: 'Two', three: 'Three' }}
-                            />
+                        <FormField
+                            name={'select_multi'}
+                            label={'Select Multi'}
+                            type={FormFieldType.ENUM_MULTI}
+                            help={'You can choose multiple'}
+                            options={{ one: 'One', two: 'Two', three: 'Three' }}
+                        />
 
-                            <FormField
-                                name={'select_one'}
-                                label={'Select One'}
-                                type={FormFieldType.ENUM}
-                                help={'Just one please'}
-                                options={{ one: 'One', two: 'Two', three: 'Three' }}
-                            />
-                        </div>
-                    )}
+                        <FormField
+                            name={'select_one'}
+                            label={'Select One'}
+                            type={FormFieldType.ENUM}
+                            help={'Just one please'}
+                            options={{ one: 'One', two: 'Two', three: 'Three' }}
+                        />
+                    </div>
+                )}
 
-                    <FormButtons>
-                        <Button variant={'contained'} color={'error'}>
-                            Reset
-                        </Button>
-                        <Button variant={'contained'} type={'submit'} color={'primary'}>
-                            Save
-                        </Button>
-                    </FormButtons>
-                </Box>
+                <FormButtons>
+                    <Button variant={'contained'} color={'error'}>
+                        Reset
+                    </Button>
+                    <Button variant={'contained'} type={'submit'} color={'primary'}>
+                        Save
+                    </Button>
+                </FormButtons>
             </FormContainer>
             <b>Submitted data</b>
             <pre>{JSON.stringify(formData, null, 2)}</pre>
@@ -260,35 +254,33 @@ export const FormWithValidation = () => {
                     setFormData(data);
                 }}
             >
-                <Box display="flex" flexDirection="column" gap={2}>
-                    <FormField name={'name'} label={'Name'} validation={['required', failValidation]} />
-                    <FormField name={'email'} label={'E-mail'} validation={['required', 'email']} />
-                    <FormField name={'enabled'} label={'Enable?'} type={FormFieldType.CHECKBOX} />
-                    <CustomFormComponent />
+                <FormField name={'name'} label={'Name'} validation={['required', failValidation]} />
+                <FormField name={'email'} label={'E-mail'} validation={['required', 'email']} />
+                <FormField name={'enabled'} label={'Enable?'} type={FormFieldType.CHECKBOX} />
+                <CustomFormComponent />
 
-                    <FormField
-                        name={'age'}
-                        label={'Age'}
-                        validation={['required', minMaxAgeCheck]}
-                        type={FormFieldType.NUMBER}
-                    />
+                <FormField
+                    name={'age'}
+                    label={'Age'}
+                    validation={['required', minMaxAgeCheck]}
+                    type={FormFieldType.NUMBER}
+                />
 
-                    <FormField
-                        name={'select_one'}
-                        label={'Select'}
-                        type={FormFieldType.RADIO}
-                        options={{ one: 'One', two: 'Two', three: 'Three' }}
-                    />
+                <FormField
+                    name={'select_one'}
+                    label={'Select'}
+                    type={FormFieldType.RADIO}
+                    options={{ one: 'One', two: 'Two', three: 'Three' }}
+                />
 
-                    <FormButtons>
-                        <Button variant={'contained'} color={'error'}>
-                            Reset
-                        </Button>
-                        <Button variant={'contained'} type={'submit'} color={'primary'}>
-                            Save
-                        </Button>
-                    </FormButtons>
-                </Box>
+                <FormButtons>
+                    <Button variant={'contained'} color={'error'}>
+                        Reset
+                    </Button>
+                    <Button variant={'contained'} type={'submit'} color={'primary'}>
+                        Save
+                    </Button>
+                </FormButtons>
             </FormContainer>
             <b>Submitted data</b>
             <pre>{JSON.stringify(formData, null, 2)}</pre>
@@ -337,39 +329,37 @@ export const FormWithAsyncValidation = () => {
                     setFormData(data);
                 }}
             >
-                <Box display="flex" flexDirection="column" gap={2}>
-                    <FormField
-                        name={'name'}
-                        label={'Name'}
-                        help={'This will fail if you type "fail"'}
-                        validation={validation}
-                    />
-                    <FormField name={'email'} label={'E-mail'} validation={['required', 'email']} />
-                    <FormField name={'enabled'} label={'Enable?'} type={FormFieldType.CHECKBOX} />
+                <FormField
+                    name={'name'}
+                    label={'Name'}
+                    help={'This will fail if you type "fail"'}
+                    validation={validation}
+                />
+                <FormField name={'email'} label={'E-mail'} validation={['required', 'email']} />
+                <FormField name={'enabled'} label={'Enable?'} type={FormFieldType.CHECKBOX} />
 
-                    <FormField
-                        name={'age'}
-                        label={'Age'}
-                        validation={['required', minMaxAgeCheck]}
-                        type={FormFieldType.NUMBER}
-                    />
+                <FormField
+                    name={'age'}
+                    label={'Age'}
+                    validation={['required', minMaxAgeCheck]}
+                    type={FormFieldType.NUMBER}
+                />
 
-                    <FormField
-                        name={'select_one'}
-                        label={'Select'}
-                        type={FormFieldType.RADIO}
-                        options={{ one: 'One', two: 'Two', three: 'Three' }}
-                    />
+                <FormField
+                    name={'select_one'}
+                    label={'Select'}
+                    type={FormFieldType.RADIO}
+                    options={{ one: 'One', two: 'Two', three: 'Three' }}
+                />
 
-                    <FormButtons>
-                        <Button variant={'contained'} color={'error'}>
-                            Reset
-                        </Button>
-                        <Button variant={'contained'} type={'submit'} color={'primary'}>
-                            Save
-                        </Button>
-                    </FormButtons>
-                </Box>
+                <FormButtons>
+                    <Button variant={'contained'} color={'error'}>
+                        Reset
+                    </Button>
+                    <Button variant={'contained'} type={'submit'} color={'primary'}>
+                        Save
+                    </Button>
+                </FormButtons>
             </FormContainer>
             <b>Submitted data</b>
             <pre>{JSON.stringify(formData, null, 2)}</pre>
@@ -389,7 +379,35 @@ export const AsyncForm = () => {
                     setFormData(data);
                 }}
             >
-                <Box display="flex" flexDirection="column" gap={2}>
+                <FormField name={'name'} label={'Name'} />
+                <FormField name={'age'} label={'Age'} type={FormFieldType.NUMBER} />
+                <FormField
+                    name={'enabled'}
+                    label={'Enable?'}
+                    type={FormFieldType.CHECKBOX}
+                    help={'Should this be enabled?'}
+                />
+
+                <FormButtons>
+                    <Button variant={'contained'} color={'error'}>
+                        Reset
+                    </Button>
+                    <Button variant={'contained'} type={'submit'} color={'primary'}>
+                        Save
+                    </Button>
+                </FormButtons>
+            </FormContainer>
+            <b>Submitted data</b>
+            <pre>{JSON.stringify(formData, null, 2)}</pre>
+        </div>
+    );
+};
+
+export const FormNavigationOnSubmit = () => {
+    return (
+        <div style={{ width: '550px' }}>
+            <form method={'GET'}>
+                <FormContainer initialValue={InitialFormValue}>
                     <FormField name={'name'} label={'Name'} />
                     <FormField name={'age'} label={'Age'} type={FormFieldType.NUMBER} />
                     <FormField
@@ -407,38 +425,6 @@ export const AsyncForm = () => {
                             Save
                         </Button>
                     </FormButtons>
-                </Box>
-            </FormContainer>
-            <b>Submitted data</b>
-            <pre>{JSON.stringify(formData, null, 2)}</pre>
-        </div>
-    );
-};
-
-export const FormNavigationOnSubmit = () => {
-    return (
-        <div style={{ width: '550px' }}>
-            <form method={'GET'}>
-                <FormContainer initialValue={InitialFormValue}>
-                    <Box display="flex" flexDirection="column" gap={2}>
-                        <FormField name={'name'} label={'Name'} />
-                        <FormField name={'age'} label={'Age'} type={FormFieldType.NUMBER} />
-                        <FormField
-                            name={'enabled'}
-                            label={'Enable?'}
-                            type={FormFieldType.CHECKBOX}
-                            help={'Should this be enabled?'}
-                        />
-
-                        <FormButtons>
-                            <Button variant={'contained'} color={'error'}>
-                                Reset
-                            </Button>
-                            <Button variant={'contained'} type={'submit'} color={'primary'}>
-                                Save
-                            </Button>
-                        </FormButtons>
-                    </Box>
                 </FormContainer>
             </form>
         </div>
@@ -460,18 +446,16 @@ export const CustomFormValidation = () => {
                 },
             ]}
         >
-            <Box display="flex" flexDirection="column" gap={2}>
-                <FormField name={'ok'} label={'Something'} validation={['required']} />
-                <FormField name={'fail'} label={'Fails'} validation={['required']} />
-                <FormButtons>
-                    <Button variant={'contained'} color={'error'}>
-                        Reset
-                    </Button>
-                    <Button variant={'contained'} type={'submit'} color={'primary'}>
-                        Save
-                    </Button>
-                </FormButtons>
-            </Box>
+            <FormField name={'ok'} label={'Something'} validation={['required']} />
+            <FormField name={'fail'} label={'Fails'} validation={['required']} />
+            <FormButtons>
+                <Button variant={'contained'} color={'error'}>
+                    Reset
+                </Button>
+                <Button variant={'contained'} type={'submit'} color={'primary'}>
+                    Save
+                </Button>
+            </FormButtons>
         </FormContainer>
     );
 };


### PR DESCRIPTION
Changes in this PR:
- Revert to have hardcoded vertical margin on form inputs (8px)
- Add a new component `DefaultFormLayout` we can wrap form inputs is. This component does two things
  - Adds a wrapper around form inputs with a gap between each
  - Removes the hardcoded margin on children with class `MuiInputBase-root`
- Change the default variant of form inputs to `"standard"`