### PR TITLE
fix: Adjust position of spinner in fields processing validation

### DIFF
--- a/src/form/inputs/FormFieldProcessingContainer.tsx
+++ b/src/form/inputs/FormFieldProcessingContainer.tsx
@@ -1,23 +1,69 @@
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, useEffect, useState } from 'react';
 import { FormFieldController } from '../formFieldController';
 import { Box, CircularProgress } from '@mui/material';
 
 interface Props extends PropsWithChildren {
     controller: FormFieldController;
+    inputElement?: HTMLInputElement | HTMLTextAreaElement;
 }
 
-export const FormFieldProcessingContainer = (props: Props) => {
+const spinnerSize = 16;
+
+/**
+ * This container adds a spinner to the input / textarea element if the controller is processing.
+ * The spinner is positioned at the right side of the element. Since MUI TextFields can have end
+ * adornments, the spinner is positioned at the end of the <input /> element and not at the end of
+ * the TextField wrapper. Vertically the spinner is positioned at the bottom of the element if it is
+ * a textarea, otherwise at the middle of the element.
+ */
+export const FormFieldProcessingContainer = ({ controller, inputElement: element, children }: Props) => {
+    const [position, setPosition] = useState({ bottom: '0px', left: '0px' });
+
+    const tagName = element?.tagName.toLowerCase() as 'input' | 'textarea';
+
+    useEffect(() => {
+        const resizeObserver = new ResizeObserver(() => {
+            if (element) {
+                if (tagName === 'input') {
+                    const rect = element.getBoundingClientRect();
+                    const style = window.getComputedStyle(element);
+                    const { paddingTop, paddingRight, paddingBottom, paddingLeft } = style;
+                    const innerHeight = rect.height - parseFloat(paddingTop) - parseFloat(paddingBottom);
+                    setPosition({
+                        bottom: parseFloat(paddingBottom) + (innerHeight - spinnerSize) / 2 + 'px',
+                        left: rect.width - parseFloat(paddingRight) - spinnerSize + 'px',
+                    });
+                } else if (tagName === 'textarea') {
+                    // We use the parent element instead for the textarea because the padding is not
+                    // in the textarea element but in the parent element.
+                    const rect = element.parentElement.getBoundingClientRect();
+                    const { paddingRight, paddingBottom } = window.getComputedStyle(element.parentElement);
+                    setPosition({
+                        bottom: paddingBottom,
+                        left: rect.width - parseFloat(paddingRight) - spinnerSize + 'px',
+                    });
+                }
+            }
+        });
+
+        if (element) {
+            resizeObserver.observe(element);
+        }
+
+        return () => resizeObserver.disconnect();
+    }, [element]);
+
     return (
         <Box position={'relative'}>
-            {props.children}
-            {props.controller.processing && (
+            {children}
+            {controller.processing && (
                 <CircularProgress
                     sx={{
                         position: 'absolute',
-                        top: '24px',
-                        right: '16px',
+                        bottom: position.bottom,
+                        left: position.left,
                     }}
-                    size={16}
+                    size={spinnerSize}
                 />
             )}
         </Box>

--- a/src/form/inputs/FormInput.tsx
+++ b/src/form/inputs/FormInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { withFormFieldController } from '../formFieldController';
 import { FormFieldProcessingContainer } from './FormFieldProcessingContainer';
 import { TextField, InputAdornment, IconButton, TextFieldProps } from '@mui/material';
@@ -57,9 +57,12 @@ export const FormInput = withFormFieldController<string | number | boolean>((pro
 
     let value = controller.value;
 
+    const inputRef = useRef<HTMLInputElement>(null);
+
     return (
-        <FormFieldProcessingContainer controller={controller}>
+        <FormFieldProcessingContainer controller={controller} inputElement={inputRef.current}>
             <TextField
+                inputRef={inputRef}
                 sx={{
                     display: 'block',
                     my: 1,

--- a/src/form/inputs/FormTextarea.tsx
+++ b/src/form/inputs/FormTextarea.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { withFormFieldController } from '../formFieldController';
 import TextField from '@mui/material/TextField';
 import { FormFieldProcessingContainer } from './FormFieldProcessingContainer';
@@ -15,9 +15,12 @@ export const FormTextarea = withFormFieldController((props: Props, controller) =
         }
     };
 
+    const inputRef = useRef<HTMLTextAreaElement>(null);
+
     return (
-        <FormFieldProcessingContainer controller={controller}>
+        <FormFieldProcessingContainer controller={controller} inputElement={inputRef.current}>
             <TextField
+                inputRef={inputRef}
                 sx={{
                     display: 'block',
                     my: 1,

--- a/stories/forms.stories.tsx
+++ b/stories/forms.stories.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useMemo, useState } from 'react';
 import { AsyncValidatorFunction, debouncedValidator, FormButtons, FormContainer } from '../src';
 import { FormField, FormFieldType } from '../src/form/inputs/FormField';
 import { FormContext, FormContextWatcher, useFormContextField } from '../src/form/FormContext';
-import { Button } from '@mui/material';
+import { Box, Button, Divider, Typography } from '@mui/material';
 
 function minMaxAgeCheck(name: string, value: number) {
     if (value < 1) {
@@ -399,6 +399,90 @@ export const FormWithAsyncValidation = () => {
             <b>Submitted data</b>
             <pre>{JSON.stringify(formData, null, 2)}</pre>
         </div>
+    );
+};
+
+export const FormWithActiveAsyncValidation = () => {
+    const asyncValidation: AsyncValidatorFunction = useMemo(
+        () =>
+            debouncedValidator(500, () => {
+                let doResolve;
+
+                const promise = new Promise((resolve) => {
+                    doResolve = resolve;
+                });
+
+                return {
+                    promise,
+                    cancel: () => {
+                        doResolve && doResolve();
+                    },
+                };
+            }),
+        []
+    );
+
+    const validation = useMemo(() => [asyncValidation], [asyncValidation]);
+
+    return (
+        <Box sx={{ width: '550px' }}>
+            <Typography variant="body1">
+                While validation is processing spinners are shown in input and textarea elements
+            </Typography>
+
+            <FormContainer>
+                <Typography variant="body2" sx={{ mt: 4 }}>
+                    input type="text"
+                </Typography>
+                <FormField name={'email'} label={'E-mail'} validation={validation} />
+                <FormField name={'email'} label={'E-mail'} validation={validation} variant="outlined" />
+                <FormField name={'email'} label={'E-mail'} validation={validation} variant="filled" />
+
+                <Typography variant="body2" sx={{ mt: 4 }}>
+                    input type="password"
+                </Typography>
+                <FormField name="password" label="Password" validation={validation} type={FormFieldType.PASSWORD} />
+                <FormField
+                    name="password"
+                    label="Password"
+                    validation={validation}
+                    variant="outlined"
+                    type={FormFieldType.PASSWORD}
+                />
+                <FormField
+                    name="password"
+                    label="Password"
+                    validation={validation}
+                    variant="filled"
+                    type={FormFieldType.PASSWORD}
+                />
+
+                <Typography variant="body2" sx={{ mt: 4 }}>
+                    textarea
+                </Typography>
+                <FormField
+                    name={'description1'}
+                    label={'Description 1'}
+                    validation={validation}
+                    variant="standard"
+                    type={FormFieldType.TEXT}
+                />
+                <FormField
+                    name={'description2'}
+                    label={'Description 2'}
+                    validation={validation}
+                    variant="outlined"
+                    type={FormFieldType.TEXT}
+                />
+                <FormField
+                    name={'description3'}
+                    label={'Description 3'}
+                    validation={validation}
+                    variant="filled"
+                    type={FormFieldType.TEXT}
+                />
+            </FormContainer>
+        </Box>
     );
 };
 


### PR DESCRIPTION
The position of the spinner was hardcoded to look good for `variant="standard"` but since we use different variants in the app this PR changes it to calculate its position based on the padding of the input field.

https://github.com/kapetacom/ui-web-components/assets/1045799/d69a0182-edec-4120-99d8-bec360d5c8bb

