### PR TITLE
fix: Export AuthProviderIcon

### DIFF
--- a/src/icons/AuthProviderIcon.tsx
+++ b/src/icons/AuthProviderIcon.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const authProviderNames = ['google', 'microsoft', 'github'] as const;
 
-type AuthProviderIconProps = {
+export type AuthProviderIconProps = {
     /**
      * The name of the auth provider
      */

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,7 @@ export * from './special/oauth/AuthScopesList';
 export * from './special/oauth/scopes';
 
 export * from './icons/AssetIcon';
+export * from './icons/AuthProviderIcon';
 export * from './avatars/AvatarEditor';
 
 export * from './terminal/XTerm';


### PR DESCRIPTION
A component is always a bit more useful when it is actually exported 😛 