### PR TITLE
Add tooltip to block status circle

### DIFF
--- a/src/blocks/components.tsx
+++ b/src/blocks/components.tsx
@@ -5,6 +5,7 @@ import { BlockContextProvider } from './context';
 import { BlockDefinition, BlockInstance } from '@kapeta/schemas';
 import { parseKapetaUri } from '@kapeta/nodejs-utils';
 import { InstanceStatus } from '@kapeta/ui-web-context';
+import { Tooltip } from '../tooltip/Tooltip';
 
 export const BlockInstanceName = (props: { onChange?: (instanceName: string) => void }) => {
     const block = useBlock();
@@ -37,10 +38,41 @@ export const BlockStatus = () => {
         [InstanceStatus.STOPPED]: 'Block has stopped',
     };
 
+    const title = titleMapping[block.status] || '';
+
+    const center = { x: 10, y: 40 };
+    const circleSize = 8;
+    const tooltipHitSize = 3 * circleSize; // The size of the hitbox for the tooltip
+    const circleRadius = circleSize / 2;
+
     return block.status ? (
-        <circle className={`instance_${block.status || InstanceStatus.STOPPED}`} r={4} cx={10} cy={40}>
-            <title>{titleMapping[block.status] || ''}</title>
-        </circle>
+        <>
+            <circle
+                className={`instance_${block.status || InstanceStatus.STOPPED}`}
+                r={circleRadius}
+                cx={center.x}
+                cy={center.y}
+            ></circle>
+
+            {/* Position on top of the circle */}
+            <foreignObject
+                x={center.x - tooltipHitSize / 2}
+                y={center.y - tooltipHitSize / 2}
+                width={tooltipHitSize}
+                height={tooltipHitSize}
+            >
+                <Tooltip title={title} arrow placement="top">
+                    <span
+                        style={{
+                            display: 'block',
+                            width: '100%',
+                            height: '100%',
+                            borderRadius: '50%',
+                        }}
+                    ></span>
+                </Tooltip>
+            </foreignObject>
+        </>
     ) : (
         <></>
     );

--- a/stories/tooltip.stories.tsx
+++ b/stories/tooltip.stories.tsx
@@ -132,3 +132,40 @@ export const Placement: Story = {
         );
     },
 };
+
+export const TooltipInSvg: Story = {
+    render: () => {
+        const title = 'Tooltip inside an SVG';
+
+        const center = { x: 50, y: 50 };
+        const circleSize = 8;
+        const circleRadius = circleSize / 2;
+        const tooltipHitSize = 3 * circleSize;
+
+        return (
+            <svg width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+                <circle r={circleRadius} cx={center.x} cy={center.y} fill="blue"></circle>
+
+                {/* Position on top of the circle */}
+                <foreignObject
+                    x={center.x - tooltipHitSize / 2}
+                    y={center.y - tooltipHitSize / 2}
+                    width={tooltipHitSize}
+                    height={tooltipHitSize}
+                >
+                    <Tooltip title={title} arrow placement="top">
+                        <span
+                            style={{
+                                display: 'block',
+                                width: '100%',
+                                height: '100%',
+                                borderRadius: '50%',
+                                border: '1px dotted #0000ff4d',
+                            }}
+                        ></span>
+                    </Tooltip>
+                </foreignObject>
+            </svg>
+        );
+    },
+};


### PR DESCRIPTION
As a new user the color of the block status is not known. This PR adds a <Tooltip> over the circle.

Titles:

- `Block is starting`
- `Block is ready`
- `Block is unhealthy`
- `Block has exited`
- `Block has stopped`

