### PR TITLE
Align size of circle with other MUI SvgIcons

### DIFF
--- a/src/charts/PieChartIcon.tsx
+++ b/src/charts/PieChartIcon.tsx
@@ -65,7 +65,7 @@ export const PieChartIcon = (props: PieChartIconProps) => {
     const size = 24;
 
     // Circle
-    const circleRadius = 9;
+    const circleRadius = 10;
     const circleStrokeWidth = 2;
 
     // Pie slice


### PR DESCRIPTION
The pie chart circle was 2 px too small when `size="medium"` compared to the MUI icons. It was noticeable when used alongside other MUI Icons.