### PR TITLE
build: enable tsc check on CI

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -13,6 +13,7 @@ jobs:
           node-version: 18
           registry-url: https://registry.npmjs.org/
       - run: npm install
+      - run: npm run lint:tsc
       - run: npm run build
         env:
           CI: true

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
         "prebuild": "rm -rf dist",
         "build": "rollup -c",
         "test": "jest",
-        "format": "prettier --write ."
+        "format": "prettier --write .",
+        "lint:tsc": "tsc --noEmit"
     },
     "peerDependencies": {
         "@emotion/react": "^11.11.1",


### PR DESCRIPTION
Basic "flip the switch" for running the typescript checker against the codebase.

We still need to turn on strict mode / strict null checks, but that is a bigger task (207/154 errors respectively).