### PR TITLE
feat: add data-kap-id to more blockhub components [KAP-1671]

### DIFF
--- a/src/blockhub/AssetInstallButton.tsx
+++ b/src/blockhub/AssetInstallButton.tsx
@@ -317,6 +317,7 @@ export const AssetInstallButton = (props: Props) => {
                             closeSubmenu();
                             await item.onClick();
                         }}
+                        data-kap-id={`asset-submenu-${item.label}`}
                     >
                         <ListItemIcon>{item.icon}</ListItemIcon>
                         <ListItemText primary={item.label} />
@@ -338,7 +339,13 @@ export const AssetInstallButton = (props: Props) => {
                 >
                     <Tooltip title={longText}>
                         <span>
-                            <Fab color={'primary'} onClick={onPrimaryClick} size={'small'} disabled={isDisabled}>
+                            <Fab
+                                color={'primary'}
+                                onClick={onPrimaryClick}
+                                size={'small'}
+                                disabled={isDisabled}
+                                data-kap-id={`asset-actionbutton-${shortText}`}
+                            >
                                 {icon}
                             </Fab>
                         </span>
@@ -367,6 +374,7 @@ export const AssetInstallButton = (props: Props) => {
             <>
                 <Tooltip title={longText}>
                     <Box
+                        data-kap-id={`asset-box-${shortText}`}
                         onClick={onPrimaryClick}
                         sx={{
                             display: 'inline-flex',
@@ -414,7 +422,9 @@ export const AssetInstallButton = (props: Props) => {
                         {isProcessing ? (
                             <CircularProgress size={18} />
                         ) : subMenu.length > 0 ? (
-                            <a onClick={onSecondaryClick}>{icon}</a>
+                            <a onClick={onSecondaryClick} data-kap-id={`asset-box-icon-${shortText}`}>
+                                {icon}
+                            </a>
                         ) : (
                             icon
                         )}
@@ -427,7 +437,13 @@ export const AssetInstallButton = (props: Props) => {
 
     return (
         <>
-            <Button variant="contained" onClick={onPrimaryClick} endIcon={icon} disabled={isDisabled}>
+            <Button
+                variant="contained"
+                onClick={onPrimaryClick}
+                endIcon={icon}
+                disabled={isDisabled}
+                data-kap-id={`asset-button-${shortText}`}
+            >
                 {longText}
                 {isProcessing && (
                     <CircularProgress

--- a/src/blockhub/AssetSortSelect.tsx
+++ b/src/blockhub/AssetSortSelect.tsx
@@ -32,6 +32,7 @@ export function AssetSortSelect(props: AssetSortSelectProps) {
 
     return (
         <Select
+            data-kap-id="blockhub-asset-sort"
             size="small"
             renderValue={(v) => {
                 return (

--- a/src/blockhub/AssetTypeFilter.tsx
+++ b/src/blockhub/AssetTypeFilter.tsx
@@ -43,6 +43,7 @@ export function AssetTypeFilter(props: AssetTypeFilterProps) {
     const options = props.options || (Object.keys(AssetTypeLabels) as AssetType[]);
     return (
         <Select
+            data-kap-id="blockhub-asset-type-filter"
             size="small"
             renderValue={(v) => {
                 return (

--- a/src/blockhub/Blockhub.tsx
+++ b/src/blockhub/Blockhub.tsx
@@ -57,6 +57,7 @@ const TileCheckbox = (props: TileCheckboxProps) => {
             onChange={(evt, checked) => {
                 props.onChange(checked);
             }}
+            data-kap-id="blockhub-tile-checkbox"
         />
     );
 };
@@ -229,6 +230,7 @@ export const Blockhub = forwardRef<HTMLDivElement, Props>((props: Props, ref) =>
                                     setTab(index);
                                     props.onCategoryChange?.(tabInfo.type);
                                 }}
+                                data-kap-id={`category-${tabInfo.type}`}
                             >
                                 <ListItemIcon>{tabInfo.icon}</ListItemIcon>
                                 <ListItemText>

--- a/src/blockhub/BlockhubDetails.tsx
+++ b/src/blockhub/BlockhubDetails.tsx
@@ -138,7 +138,7 @@ export function BlockhubDetails(props: BlockhubDetailsProps) {
             }}
         >
             <Box p={3} position={'fixed'}>
-                <Button color="inherit" onClick={props.onBackAction}>
+                <Button color="inherit" onClick={props.onBackAction} data-kap-id="blockhub-details-back-button">
                     <ArrowBack />
                     Back
                 </Button>
@@ -195,12 +195,19 @@ export function BlockhubDetails(props: BlockhubDetailsProps) {
                         sx={(theme) => ({ borderBottom: '1px solid ' + theme.palette.divider })}
                         onChange={(_e, tabValue) => props.onTabChange(tabValue)}
                     >
-                        <KapetaTab value={'general'} label={'General'} />
+                        <KapetaTab value={'general'} label={'General'} data-kap-id="blockhub-details-tab-general" />
                         <KapetaTab
                             value={'dependencies'}
                             label={[props.asset.dependencies?.length || '', 'Dependencies'].filter(Boolean).join(' ')}
+                            data-kap-id="blockhub-details-tab-dependencies"
                         />
-                        {props.versionInfo && <KapetaTab value={'versions'} label={'Versions'} />}
+                        {props.versionInfo && (
+                            <KapetaTab
+                                value={'versions'}
+                                label={'Versions'}
+                                data-kap-id="blockhub-details-tab-versions"
+                            />
+                        )}
                     </Tabs>
 
                     <TabContainer open={currentTab === 'general'}>

--- a/src/blockhub/BlockhubTile.tsx
+++ b/src/blockhub/BlockhubTile.tsx
@@ -21,13 +21,20 @@ export function BlockhubStats(props: { stats: { rating?: number; downloads?: num
         <Stack className="metrics">
             {/* Downloads */}
             {typeof props.stats.downloads !== 'undefined' ? (
-                <Stack direction={'row'} gap={1} alignItems={'center'} justifyContent={'flex-end'}>
+                <Stack
+                    direction={'row'}
+                    gap={1}
+                    alignItems={'center'}
+                    justifyContent={'flex-end'}
+                    data-kap-id="blockhub-download-count"
+                >
                     <Typography variant="caption">{props.stats.downloads.toLocaleString()}</Typography>
                     <TrendingUpIcon sx={(theme) => ({ color: theme.palette.success.light })} />
                 </Stack>
             ) : null}
             {typeof props.stats.rating !== 'undefined' ? (
                 <Rating
+                    data-kap-id="blockhub-tile-rating"
                     name="read-only"
                     title={`${props.stats.rating} / 5`}
                     value={props.stats.rating}
@@ -121,6 +128,7 @@ export function BlockhubTile(props: BlockhubTileProps) {
                     width: '100%',
                     height: '100%',
                 }}
+                data-kap-id="blockhub-tile-link"
             >
                 {content}
             </Link>
@@ -206,7 +214,12 @@ export function BlockhubTile(props: BlockhubTileProps) {
                         <Stack direction={'row'} gap={2} justifyContent="space-between" alignItems={'flex-end'}>
                             <Stack sx={{ fontSize: '12px' }} gap={'4px'} minWidth={0}>
                                 {props.version ? (
-                                    <Box sx={{ textDecoration: 'underline', lineHeight: '166%' }}>{props.version}</Box>
+                                    <Box
+                                        sx={{ textDecoration: 'underline', lineHeight: '166%' }}
+                                        data-kap-id="blockhub-tile-version"
+                                    >
+                                        {props.version}
+                                    </Box>
                                 ) : null}
                                 <Stack className="labels" direction={'row'} gap="5px" alignItems={'center'}>
                                     {props.languageTargetLabel}

--- a/src/blockhub/asset-helpers.tsx
+++ b/src/blockhub/asset-helpers.tsx
@@ -67,7 +67,7 @@ export function renderRepository(repository: AssetRepositoryInfo) {
 
     return (
         <div className={'repository'}>
-            <a href={url} target={'_blank'}>
+            <a href={url} target={'_blank'} data-kap-id="blockhub-asset-github-link">
                 <i className={iconClass} />
                 {shortUrl}
             </a>


### PR DESCRIPTION
Used the following selector in dev mode:
```css
// poor mans devtools - highlight elements with kap-id
[data-kap-id] {
    box-shadow: 0 0 5px #f00 !important;
}
```

<img width="1530" alt="Screenshot 2023-10-30 at 15 59 31" src="https://github.com/kapetacom/ui-web-components/assets/296057/9d71ced5-7951-40be-9bf7-8639e845b248">
<img width="1530" alt="Screenshot 2023-10-30 at 16 10 29" src="https://github.com/kapetacom/ui-web-components/assets/296057/9b09dc89-f93a-4195-98a0-0dee1ea6656e">
