### PR TITLE
feat: add type args for FormContainer data

### DIFF
--- a/src/dialogs/KapFormDialog.tsx
+++ b/src/dialogs/KapFormDialog.tsx
@@ -7,13 +7,13 @@ import React, { PropsWithChildren, ReactNode } from 'react';
 import { KapDialog, KapDialogProps } from './KapDialog';
 import { FormContainer, FormContainerProps } from '../form/FormContainer';
 
-export type KapFormDialogProps<OnCloseFn extends (...args: any[]) => any> = PropsWithChildren<{
+export type KapFormDialogProps<OnCloseFn extends (...args: any[]) => any, TFormData = any> = PropsWithChildren<{
     open: KapDialogProps<OnCloseFn>['open'];
     onClose: OnCloseFn;
     title?: ReactNode;
     actions?: ReactNode;
 }> &
-    Omit<FormContainerProps, 'children'>;
+    Omit<FormContainerProps<TFormData>, 'children'>;
 
 export const KapFormDialog = <OnCloseFn extends (...args: any[]) => any>({
     open,


### PR DESCRIPTION
Will enfore `FormContainer` and `KapFormDialog` callbacks to match the type of the `initialValue` type.

Example w/ `initialValue` having the type `BlockConfigurationData`:

<img width="966" alt="Screenshot 2023-11-02 at 23 13 10" src="https://github.com/kapetacom/ui-web-components/assets/296057/7670dcb1-4d6d-4acc-a4c0-0c2ece721fe5">

