### PR TITLE
fix: allow null returns from AssetFetcher

### DIFF
--- a/src/blockhub/BlockhubDetails.tsx
+++ b/src/blockhub/BlockhubDetails.tsx
@@ -65,7 +65,7 @@ const AutoLoadingTile = (props: Props) => {
               downloads: assetReq.data.downloadCount,
           }
         : undefined;
-    const asset: AssetDisplay<any> | undefined = assetReq.isLoading ? undefined : assetReq.data;
+    const asset = assetReq.data;
 
     const url = props.linkMaker ? props.linkMaker(fullName, version) : `/${fullName}/${version}`;
 

--- a/src/blockhub/types.ts
+++ b/src/blockhub/types.ts
@@ -5,7 +5,7 @@
 
 import { Asset, SchemaKind } from '@kapeta/ui-web-types';
 
-export type AssetFetcher = (name: string, version: string) => Promise<AssetDisplay | undefined>;
+export type AssetFetcher = (name: string, version: string) => Promise<AssetDisplay | null>;
 
 export enum CoreTypes {
     CORE = 'core/core',

--- a/stories/blockhub.data.ts
+++ b/stories/blockhub.data.ts
@@ -598,7 +598,7 @@ export const Assets: AssetDisplay[] = [
 ];
 
 export const assetFetcher: AssetFetcher = async (name: string, version: string) => {
-    return Assets.find((a) => a.version === version && a.content.metadata.name === name);
+    return Assets.find((a) => a.version === version && a.content.metadata.name === name) || null;
 };
 
 export const AssetAuthor = {


### PR DESCRIPTION
`null` is more in line with an explicit "nothing", and compatible w/ our REST clients that return null on 404.