### PR TITLE
KAP-1888 Support for adding arguments to header attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3953,9 +3953,9 @@
             }
         },
         "node_modules/@kapeta/ui-web-types": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/@kapeta/ui-web-types/-/ui-web-types-0.1.1.tgz",
-            "integrity": "sha512-ffAtBU1fBC0WufEXeBFMttfAQ4+YjeavJQ/UdWxLHHJZCoNWZEad5RShRQdeFco/GtdrX+SsP+wT94kopeZ2xA==",
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/@kapeta/ui-web-types/-/ui-web-types-0.1.2.tgz",
+            "integrity": "sha512-KOYA/1X7u+m8vu3N7hMGbH45N/0653GpEn3naN5qLX+TYpA9RXGDQTybNNjY+gSyBHE2Ez7dTa8EY8pzzK7jUg==",
             "dev": true,
             "peerDependencies": {
                 "@types/lodash": "4",

--- a/src/dsl/DSLConverters.ts
+++ b/src/dsl/DSLConverters.ts
@@ -321,6 +321,7 @@ export namespace DSLConverters {
                                   ? [
                                         {
                                             type: fromSchemaTransport(arg.transport),
+                                            argument: arg.argument,
                                         },
                                     ]
                                   : [],
@@ -344,11 +345,13 @@ export namespace DSLConverters {
             const args: RESTMethod['arguments'] = {};
             if (method.parameters) {
                 method.parameters.forEach((arg) => {
+                   let restArgs = !(arg.annotations && arg.annotations.length > 0) ? "" : (arg.annotations[0].arguments && arg.annotations[0].arguments[0])
                     args[arg.name] = {
                         ...toSchemaType(arg.type),
                         transport: toSchemaTransport(
                             arg.annotations && arg.annotations.length > 0 ? arg.annotations[0].type : '@Query'
                         ),
+                        argument: restArgs,
                     };
                 });
             }

--- a/test/dsl/DSLConverters.test.ts
+++ b/test/dsl/DSLConverters.test.ts
@@ -367,6 +367,45 @@ describe('DSLConverters', () => {
             });
         });
 
+        test('can convert methods to schema with arguments', () => {
+            const methods: DSLMethod[] = [
+                {
+                    type: DSLEntityType.METHOD,
+                    name: 'test',
+                    annotations: [
+                        {
+                            type: '@GET',
+                            arguments: ['/path'],
+                        },
+                    ],
+                    description: 'Test',
+                    parameters: [
+                        {
+                            type: { name: 'string', list: true },
+                            annotations: [{ type: '@Header', arguments: ['X-Kapeta-Tags'] }],
+                            name: 'tags',
+                        },
+                    ],
+                    returnType: { name: 'string', list: true },
+                }
+            ];
+            expect(DSLConverters.toSchemaMethods(methods)).toEqual({
+                test: {
+                    description: 'Test',
+                    method: 'GET',
+                    path: '/path',
+                    arguments: {
+                        tags: {
+                            type: 'string[]',
+                            transport: 'HEADER',
+                            argument: 'X-Kapeta-Tags'
+                        },
+                    },
+                    responseType: { type: 'string[]' },
+                },
+            });
+        });
+
         test('can convert methods from schema', () => {
             const methods: { [key: string]: RESTMethod } = {
                 test: {
@@ -435,5 +474,47 @@ describe('DSLConverters', () => {
                 },
             ]);
         });
+    });
+
+    test('can convert methods from schema with Header arguments', () => {
+        const methods: { [key: string]: RESTMethod } = {
+            test: {
+                description: 'Test',
+                method: HTTPMethod.GET,
+                path: '/path',
+                arguments: {
+                    tags: {
+                        type: 'string[]',
+                        transport: 'HEADER',
+                        argument: 'X-Kapeta-Tags'
+                    },
+
+                },
+                responseType: { type: 'string[]' },
+            },
+        };
+        expect(DSLConverters.fromSchemaMethods(methods)).toEqual([
+            {
+                type: DSLEntityType.METHOD,
+                name: 'test',
+                annotations: [
+                    {
+                        type: '@GET',
+                        arguments: ['/path'],
+                    },
+                ],
+                description: 'Test',
+                parameters: [
+                    {
+                        type: { name: 'string', list: true },
+                        annotations: [
+                            { type: '@Header' , argument: 'X-Kapeta-Tags' }
+                        ],
+                        name: 'tags',
+                    },
+                ],
+                returnType: { name: 'string', list: true },
+            },
+        ]);
     });
 });

--- a/test/dsl/DSLParser.test.ts
+++ b/test/dsl/DSLParser.test.ts
@@ -115,6 +115,54 @@ describe('DSLParser', () => {
         ]);
     });
 
+    test('can parse REST method with Header', () => {
+        expect(
+            DSLParser.parse(
+                [
+                    '//Some',
+                    '//description',
+                    '@POST("/some/path")',
+                    'myMethod(@Header("My-Header") header: string, @Path id:string, @Query tags:string[], @Body entity:MyClass):void',
+                ].join('\n'),
+                {
+                    methods: true,
+                    rest: true,
+                    validTypes: ['MyClass'],
+                }
+            ).entities
+        ).toEqual([
+            {
+                type: DSLEntityType.METHOD,
+                description: 'Some\ndescription',
+                returnType: 'void',
+                name: 'myMethod',
+                annotations: [{ type: '@POST', arguments: ['/some/path'] }],
+                parameters: [
+                    {
+                        name: 'header',
+                        type: 'string',
+                        annotations: [{ type: '@Header', arguments: ['My-Header'] }],
+                    },
+                    {
+                        name: 'id',
+                        type: 'string',
+                        annotations: [{ type: '@Path', arguments: [] }],
+                    },
+                    {
+                        name: 'tags',
+                        type: { name: 'string', list: true },
+                        annotations: [{ type: '@Query', arguments: [] }],
+                    },
+                    {
+                        name: 'entity',
+                        type: 'MyClass',
+                        annotations: [{ type: '@Body', arguments: [] }],
+                    },
+                ],
+            },
+        ]);
+    });
+
     test('can parse data type', () => {
         expect(
             DSLParser.parse(


### PR DESCRIPTION
Seems like we were missing the information about the header arguments. This should add support for that to the DSL