### PR TITLE
fix: load monaco-editor from node_modules instead of CDN

### DIFF
--- a/src/dsl/DSLLanguage.ts
+++ b/src/dsl/DSLLanguage.ts
@@ -4,6 +4,7 @@
  */
 
 import { languages, editor } from 'monaco-editor';
+import * as monaco from 'monaco-editor';
 import loader from '@monaco-editor/loader';
 import IRichLanguageConfiguration = languages.LanguageConfiguration;
 import ILanguage = languages.IMonarchLanguage;
@@ -174,8 +175,12 @@ export const withAdditionalTypes = (model: editor.ITextModel, types: string[]) =
     completionItemProvider.setAdditionalTypes(model, types);
 };
 
-loader.init().then((monaco) => {
-    const languages = monaco.languages;
+loader.config({
+    monaco
+});
+
+loader.init().then((monacoInstance) => {
+    const languages = monacoInstance.languages;
     languages.register({ id: DSL_LANGUAGE_ID });
 
     languages.onLanguage(DSL_LANGUAGE_ID, () => {


### PR DESCRIPTION
Implements the loader config from the docs:
https://github.com/suren-atoyan/monaco-loader#configure-the-loader-to-load-the-monaco-as-an-npm-package

```
import loader from '@monaco-editor/loader';
import * as monaco from 'monaco-editor';

loader.config({ monaco });

loader.init().then(monacoInstance => { /* ... */ });
```

Ensuring that we actually use the monaco instance that we have bundled from node_modules.