### PR TITLE
fix: Return 0s for durations < 1000

### DIFF
--- a/src/dates/TimeDuration.tsx
+++ b/src/dates/TimeDuration.tsx
@@ -13,8 +13,14 @@ import { Box, BoxProps } from '@mui/material';
  * @example toTimeDuration(0, 86401000) // 1d, 1s
  */
 export const toTimeDuration = (from: number, to: number) => {
-    const duration = Duration.fromMillis(to - from).shiftTo('days', 'hours', 'minutes', 'seconds', 'milliseconds');
+    const totalMillis = to - from;
 
+    // Directly return "0s" for durations less than 1000 milliseconds
+    if (totalMillis < 1000) {
+        return '0s';
+    }
+
+    const duration = Duration.fromMillis(totalMillis).shiftTo('days', 'hours', 'minutes', 'seconds', 'milliseconds');
     const format = "d'd', h'h', m'm', s's'";
 
     let formattedDuration = duration.toFormat(format);

--- a/stories/dates.stories.tsx
+++ b/stories/dates.stories.tsx
@@ -186,6 +186,9 @@ export const TimeDurationExamples = () => {
     return renderTimeDurationRows([
         { props: { from: 0, to: minutes(35) + seconds(15) } },
 
+        { props: { duration: 0 } },
+        { props: { duration: 999 } },
+
         { props: { duration: seconds(2) } },
 
         { props: { duration: minutes(35) } },


### PR DESCRIPTION
Durations less than 1000ms didn't return "0s". This fixes that.