### PR TITLE
Make KapButton stylable

### DIFF
--- a/src/blockhub/AssetTypeFilter.tsx
+++ b/src/blockhub/AssetTypeFilter.tsx
@@ -6,8 +6,7 @@
 import React from 'react';
 import { Box, MenuItem, Select } from '@mui/material';
 import { CoreTypes } from './types';
-
-import { FilterList } from '@mui/icons-material';
+import FilterListIcon from '@mui/icons-material/FilterList';
 
 export const AssetTypes = {
     PLAN: [CoreTypes.PLAN],
@@ -49,7 +48,7 @@ export function AssetTypeFilter(props: AssetTypeFilterProps) {
             renderValue={(v) => {
                 return (
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: '.5em' }}>
-                        <FilterList />
+                        <FilterListIcon />
                         <span className="Value">Filter: {AssetTypeLabels[v]}</span>
                     </Box>
                 );

--- a/src/button/KapButton.tsx
+++ b/src/button/KapButton.tsx
@@ -12,7 +12,7 @@ export type KapButtonProps<C extends ElementType = 'button'> = ButtonProps<C, { 
 };
 
 export const KapButton = (props: KapButtonProps<ElementType>) => {
-    const { children, loading, ...buttonProps } = props;
+    const { children, loading, sx, ...buttonProps } = props;
 
     const sizeToSpinnerSize = {
         small: 16,
@@ -27,6 +27,7 @@ export const KapButton = (props: KapButtonProps<ElementType>) => {
         <Button
             {...buttonProps}
             sx={{
+                ...sx,
                 overflow: 'hidden',
                 '.button-text': {
                     opacity: 0,

--- a/stories/KapButton.stories.tsx
+++ b/stories/KapButton.stories.tsx
@@ -95,3 +95,57 @@ export const Loading: Story = {
         );
     },
 };
+
+export const CustomStyle: Story = {
+    render: () => {
+        const [loading, setLoading] = useState(false);
+        const [disabled, setDisabled] = useState(false);
+
+        return (
+            <Box>
+                <Stack direction="column" spacing={0}>
+                    <FormControlLabel
+                        control={<Switch checked={loading} onChange={() => setLoading(!loading)} />}
+                        label="Loading"
+                    />
+                    <FormControlLabel
+                        control={<Switch checked={disabled} onChange={() => setDisabled(!disabled)} />}
+                        label="Disabled"
+                    />
+                </Stack>
+
+                <KapButton
+                    // Just some random styles to show that you can style the button as you like
+                    sx={{
+                        mt: 2,
+                        background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',
+                        color: 'white',
+                        fontStyle: 'italic',
+                        fontWeight: 'bold',
+                        fontSize: '16px',
+                        fontFamily: 'Garamond, serif',
+                        outline: '3px solid green',
+                        boxShadow: '0 3px 5px 2px rgba(255, 105, 135, .3)',
+                        transition: 'transform 0.3s ease-in-out',
+                        '&:hover': {
+                            transform: 'scale(1.1)',
+                            boxShadow: '0 6px 10px 4px rgba(255, 105, 135, .5)',
+                        },
+                        '&.Mui-disabled': {
+                            background: 'linear-gradient(45deg, #CCCCCC 30%, #EEEEEE 90%)',
+                            color: '#666666',
+                            fontStyle: 'normal',
+                            outline: '3px dotted pink',
+                            boxShadow: 'none',
+                            cursor: 'not-allowed',
+                        },
+                    }}
+                    loading={loading}
+                    disabled={disabled}
+                >
+                    Funky button
+                </KapButton>
+            </Box>
+        );
+    },
+};


### PR DESCRIPTION
`KapButton` couldn't be styled from the outside. This PR changes that.
<img width="513" alt="image" src="https://github.com/kapetacom/ui-web-components/assets/1045799/9b61565f-e2cc-417a-b93b-7015d359b43a">
