### PR TITLE
feat: Add right sidebar opened/closed icons

### DIFF
--- a/src/icons/RightSidebarIcon.tsx
+++ b/src/icons/RightSidebarIcon.tsx
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2024 Kapeta Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { SvgIcon, SvgIconProps } from '@mui/material';
+import React, { ForwardedRef, forwardRef } from 'react';
+
+export interface RightSidebarIconProps extends SvgIconProps {}
+
+export const RightSidebarIcon = forwardRef((props: RightSidebarIconProps, ref: ForwardedRef<SVGSVGElement>) => {
+    return (
+        <SvgIcon {...props} ref={ref}>
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <rect
+                    x="3.17857"
+                    y="3.17857"
+                    width="17.6429"
+                    height="17.6429"
+                    rx="2.03571"
+                    stroke="currentColor"
+                    strokeWidth="1.35714"
+                />
+                <path d="M14.7148 3.85938H16.072V20.1451H14.7148V3.85938Z" fill="currentColor" />
+            </svg>
+        </SvgIcon>
+    );
+});

--- a/src/icons/RightSidebarOpenedIcon.tsx
+++ b/src/icons/RightSidebarOpenedIcon.tsx
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2024 Kapeta Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { SvgIcon, SvgIconProps } from '@mui/material';
+import React, { ForwardedRef, forwardRef } from 'react';
+
+export interface RightSidebarOpenedIconProps extends SvgIconProps {}
+
+export const RightSidebarOpenedIcon = forwardRef(
+    (props: RightSidebarOpenedIconProps, ref: ForwardedRef<SVGSVGElement>) => {
+        return (
+            <SvgIcon {...props} ref={ref}>
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <rect
+                        x="3.17857"
+                        y="3.17857"
+                        width="17.6429"
+                        height="17.6429"
+                        rx="2.24451"
+                        stroke="currentColor"
+                        strokeWidth="1.35714"
+                    />
+                    <path d="M14.7148 3.85938H20.1434V20.1451H14.7148V3.85938Z" fill="currentColor" />
+                </svg>
+            </SvgIcon>
+        );
+    }
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,6 +108,8 @@ export * from './icons/PromoIcon';
 export * from './icons/DonutProgressIcon';
 export * from './icons/HenrikIcon';
 export * from './icons/AIEventIcon';
+export * from './icons/RightSidebarIcon';
+export * from './icons/RightSidebarOpenedIcon';
 export * from './avatars/AvatarEditor';
 
 export * from './terminal/XTerm';

--- a/stories/icons/RightSidebarIcon.stories.tsx
+++ b/stories/icons/RightSidebarIcon.stories.tsx
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2024 Kapeta Inc.
+ * SPDX-License-Identifier: MIT
+ */
+
+import { RightSidebarIcon } from '../../src/icons/RightSidebarIcon';
+import { StoryObj } from '@storybook/react';
+import React from 'react';
+import { Tooltip } from '../../src';
+import { Box, Stack } from '@mui/material';
+
+const meta = {
+    title: 'Icons/RightSidebarIcon',
+    component: RightSidebarIcon,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof RightSidebarIcon>;
+
+export const Basic: Story = {};
+
+export const WithTooltip: Story = {
+    render: (args) => {
+        return (
+            <Tooltip title="This is a tooltip" placement="right">
+                <RightSidebarIcon {...args} />
+            </Tooltip>
+        );
+    },
+};
+
+export const Sizes: Story = {
+    render: () => {
+        return (
+            <Stack gap={1}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <RightSidebarIcon fontSize="large" />
+                    large
+                </Box>
+
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <RightSidebarIcon fontSize="medium" />
+                    medium
+                </Box>
+
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <RightSidebarIcon fontSize="small" />
+                    small
+                </Box>
+            </Stack>
+        );
+    },
+};

--- a/stories/icons/RightSidebarOpenedIcon.stories.tsx
+++ b/stories/icons/RightSidebarOpenedIcon.stories.tsx
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2024 Kapeta Inc.
+ * SPDX-License-Identifier: MIT
+ */
+
+import { RightSidebarOpenedIcon } from '../../src/icons/RightSidebarOpenedIcon';
+import { StoryObj } from '@storybook/react';
+import React from 'react';
+import { Tooltip } from '../../src';
+import { Box, Stack } from '@mui/material';
+
+const meta = {
+    title: 'Icons/RightSidebarOpenedIcon',
+    component: RightSidebarOpenedIcon,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof RightSidebarOpenedIcon>;
+
+export const Basic: Story = {};
+
+export const WithTooltip: Story = {
+    render: (args) => {
+        return (
+            <Tooltip title="This is a tooltip" placement="right">
+                <RightSidebarOpenedIcon {...args} />
+            </Tooltip>
+        );
+    },
+};
+
+export const Sizes: Story = {
+    render: () => {
+        return (
+            <Stack gap={1}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <RightSidebarOpenedIcon fontSize="large" />
+                    large
+                </Box>
+
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <RightSidebarOpenedIcon fontSize="medium" />
+                    medium
+                </Box>
+
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <RightSidebarOpenedIcon fontSize="small" />
+                    small
+                </Box>
+            </Stack>
+        );
+    },
+};


### PR DESCRIPTION
Opened
<img width="42" alt="image" src="https://github.com/kapetacom/ui-web-components/assets/1045799/9c02a233-e345-4b1b-85db-2bbce231f15c">

Closed
<img width="33" alt="image" src="https://github.com/kapetacom/ui-web-components/assets/1045799/2090a5fc-3c4e-43dd-8da2-8f1b6f86968c">
