### PR TITLE
fix: Apply filter to kind icons (only images)

### DIFF
--- a/src/icons/AssetIcon.tsx
+++ b/src/icons/AssetIcon.tsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import { IconValue, Kind } from '@kapeta/schemas';
 import './AssetIcon.less';
+import { useTheme } from '@mui/material';
 
 interface KindIconProps {
     kind: string;
@@ -16,6 +17,7 @@ interface KindIconProps {
 
 export const KindIcon = (props: KindIconProps) => {
     const size = props.size || 16;
+    const isDarkMode = useTheme().palette.mode === 'dark';
     const style = {
         fontSize: size + 'px',
         height: size + 'px',
@@ -25,7 +27,17 @@ export const KindIcon = (props: KindIconProps) => {
             case 'fontawesome5':
                 return <i style={style} className={`asset-icon ${props.icon.value}`} title={props.title} />;
             case 'url':
-                return <img style={style} className="asset-icon" src={props.icon.value} alt={props.title} />;
+                return (
+                    <img
+                        style={{
+                            ...style,
+                            ...(isDarkMode && { filter: 'invert(1) brightness(2) contrast(1.5)' }),
+                        }}
+                        className="asset-icon"
+                        src={props.icon.value}
+                        alt={props.title}
+                    />
+                );
         }
     }
 


### PR DESCRIPTION
The icon here is visible because of css filter (only applied in dark mode)

<img width="386" alt="image" src="https://github.com/kapetacom/ui-web-components/assets/1045799/7f1e9a1b-3636-4a2d-99a1-0fd0838ee947">
