### PR TITLE
Add border to dsl-editor

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -2,9 +2,10 @@ import React, { useMemo } from 'react';
 import { Preview } from '@storybook/react';
 import { configure } from 'mobx';
 import { MemoryRouter } from 'react-router-dom';
-import { CssBaseline, ThemeProvider, createTheme } from '@mui/material';
+import { Box, CssBaseline, GlobalStyles, ThemeProvider, createTheme } from '@mui/material';
 import { lightTheme, darkTheme } from '@kapeta/style';
 import '../styles/index.less';
+import { useNiceScrollbars } from '../src/utils/scrollbars';
 
 configure({
     enforceActions: 'always',
@@ -22,7 +23,7 @@ const THEMES = {
     dark: createTheme(darkTheme as any),
 };
 
-export const withMuiTheme = (Story, context) => {
+const withMuiTheme = (Story, context) => {
     // The theme global we just declared
     const { theme: themeKey } = context.globals;
 
@@ -30,14 +31,54 @@ export const withMuiTheme = (Story, context) => {
     const theme = useMemo(() => THEMES[themeKey] || THEMES['light'], [themeKey]);
 
     return (
-        <div>
-            <ThemeProvider theme={theme}>
-                <CssBaseline />
-                <MemoryRouter>
-                    <Story />
-                </MemoryRouter>
-            </ThemeProvider>
-        </div>
+        <ThemeProvider theme={theme}>
+            <CssBaseline />
+            <GlobalStyles
+                styles={{
+                    html: { height: '100%', width: '100%' },
+                    body: {
+                        height: '100%',
+                        width: '100%',
+                        backgroundColor: themeKey === 'side-by-side' ? '#e4e4e4' : undefined,
+                    },
+                    '#storybook-root': { height: '100%', width: '100%', display: 'flex' },
+                }}
+            />
+
+            {themeKey === 'side-by-side' ? (
+                // If the theme is side-by-side, render the story twice in two different themes
+                <Box sx={{ display: 'flex', gap: '1rem', width: '100%', height: '100%' }}>
+                    <ThemeProvider theme={THEMES['light']}>
+                        <Box
+                            sx={(theme) => ({
+                                display: 'flex',
+                                flex: 1,
+                                backgroundColor: 'background.paper',
+                                overflow: 'auto',
+                                ...useNiceScrollbars(theme.palette.background.paper),
+                            })}
+                        >
+                            <Story />
+                        </Box>
+                    </ThemeProvider>
+                    <ThemeProvider theme={THEMES['dark']}>
+                        <Box
+                            sx={(theme) => ({
+                                display: 'flex',
+                                flex: 1,
+                                backgroundColor: theme.palette.background.paper,
+                                overflow: 'auto',
+                                ...useNiceScrollbars(theme.palette.background.paper),
+                            })}
+                        >
+                            <Story />
+                        </Box>
+                    </ThemeProvider>
+                </Box>
+            ) : (
+                <Story />
+            )}
+        </ThemeProvider>
     );
 };
 
@@ -57,6 +98,7 @@ const preview: Preview = {
                 items: [
                     { value: 'light', left: '☀️', title: 'Light mode' },
                     { value: 'dark', left: '🌙', title: 'Dark mode' },
+                    { value: 'side-by-side', left: '🌗', title: 'Side by side' },
                 ],
             },
         },

--- a/src/dsl/DSLEditor.tsx
+++ b/src/dsl/DSLEditor.tsx
@@ -16,7 +16,7 @@ import { DSLValidator } from './DSLValidator';
 import { withAdditionalTypes } from './DSLLanguage';
 import { DSLLanguageOptions, DSLParser, DSLParserOptions, DSLResult, KaplangWriter } from '@kapeta/kaplang-core';
 import { DSL_LANGUAGE_ID } from './types';
-import { useTheme } from '@mui/material';
+import { Box, useTheme } from '@mui/material';
 
 export interface DSLEditorProps extends DSLLanguageOptions {
     value?: DSLResult | string;
@@ -76,9 +76,9 @@ export const DSLEditor = (props: DSLEditorProps) => {
     const isDarkMode = useTheme().palette.mode === 'dark';
 
     return (
-        <div className={'dsl-editor'}>
+        <Box className={'dsl-editor'} sx={(theme) => ({ p: 1, border: `1px solid ${theme.palette.divider}` })}>
             <Monaco
-                theme={isDarkMode ? 'vs-dark' : 'vs-light'}
+                theme={isDarkMode ? 'vs-dark' : 'light'}
                 options={options}
                 value={current}
                 onChange={(code) => {
@@ -118,6 +118,6 @@ export const DSLEditor = (props: DSLEditorProps) => {
                     }
                 }}
             />
-        </div>
+        </Box>
     );
 };


### PR DESCRIPTION
Adding a border again (removed in earlier PR) because when in light mode it is not clear where the editor starts and ends when it has the same background color.

![image](https://github.com/kapetacom/ui-web-components/assets/1045799/e2d3403c-251e-4ca1-80c0-e30d67f5f5de)
