### PR TITLE
fix: Make DSL editor wrapper easier to style from the outside

### DIFF
--- a/src/dsl/DSLEditor.tsx
+++ b/src/dsl/DSLEditor.tsx
@@ -16,7 +16,7 @@ import { DSLValidator } from './DSLValidator';
 import { withAdditionalTypes } from './DSLLanguage';
 import { DSLLanguageOptions, DSLParser, DSLParserOptions, DSLResult, KaplangWriter } from '@kapeta/kaplang-core';
 import { DSL_LANGUAGE_ID } from './types';
-import { Box, useTheme } from '@mui/material';
+import { Box, BoxProps, useTheme } from '@mui/material';
 
 export interface DSLEditorProps extends DSLLanguageOptions {
     value?: DSLResult | string;
@@ -25,6 +25,11 @@ export interface DSLEditorProps extends DSLLanguageOptions {
     onChange?: (structure: DSLResult) => any;
     onCodeChange?: (code: string) => any;
     onError?: (err: any) => any;
+    /**
+     * Around the DSLEditor there is a wrapping div. This property allows to pass props to this div
+     * (MUI Box component)
+     */
+    wrapperProps?: BoxProps;
 }
 
 export const DSLEditor = (props: DSLEditorProps) => {
@@ -76,7 +81,7 @@ export const DSLEditor = (props: DSLEditorProps) => {
     const isDarkMode = useTheme().palette.mode === 'dark';
 
     return (
-        <Box className={'dsl-editor'} sx={(theme) => ({ p: 1, border: `1px solid ${theme.palette.divider}` })}>
+        <Box className={'dsl-editor'} {...props.wrapperProps}>
             <Monaco
                 theme={isDarkMode ? 'vs-dark' : 'light'}
                 options={options}

--- a/stories/dsl.stories.tsx
+++ b/stories/dsl.stories.tsx
@@ -488,6 +488,31 @@ DslEditorRestObject.story = {
     name: 'DSL Editor (REST - Object)',
 };
 
+export const DslEditorCustomWrapper = () => (
+    <DSLEditor
+        types={true}
+        methods={true}
+        rest={true}
+        onChange={(result) => console.log('result', result)}
+        value={{
+            code: '',
+            entities: [...DATA_TYPE_ENTITIES, ...REST_METHOD_ENTITIES],
+        }}
+        wrapperProps={{
+            sx: {
+                // Rainbow border to show off that you can style the wrapper around the DSL editor
+                border: '32px solid',
+                borderImage: 'linear-gradient(45deg, red, orange, yellow, green, blue, indigo, violet) 1',
+                padding: 4,
+            },
+        }}
+    />
+);
+
+DslEditorRestObject.story = {
+    name: 'DSL Editor (REST - Object)',
+};
+
 export const RestMethodEditor = () => (
     <MethodEditor
         value={REST_METHODS}
@@ -561,14 +586,15 @@ ConfigurationEditorObject.story = {
 };
 
 export const _ModelEditor = () => (
-    <ModelEditor value={MODELS} onChange={(result) => console.log('result', result)} onError={(result) => console.error('error', result)}/>
+    <ModelEditor
+        value={MODELS}
+        onChange={(result) => console.log('result', result)}
+        onError={(result) => console.error('error', result)}
+    />
 );
 
 export const ModelEditorObject = () => (
-    <ModelEditor
-        value={{ entities: MODELS_ENTITIES, code: '' }}
-        onChange={(result) => console.log('result', result)}
-    />
+    <ModelEditor value={{ entities: MODELS_ENTITIES, code: '' }} onChange={(result) => console.log('result', result)} />
 );
 
 ModelEditorObject.story = {


### PR DESCRIPTION
The reason for this change is that in light mode we probably always want to add a border around the editor to make it clear where it starts and ends. In dark mode we only want to have a border if the DSL Editor is used on a background with the same background color as the editor background.

Now we can control it from the outside much easier

<img width="1560" alt="image" src="https://github.com/kapetacom/ui-web-components/assets/1045799/372f57e5-86bf-4242-bd5e-693750e00da5">
